### PR TITLE
Add missing bing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "dependencies": {
     "es6-promise": "^4.1.1",
     "leaflet": "^1.2.0",
+    "leaflet-bing-layer": "^3.2.0",
     "leaflet-fullscreen": "^1.0.2",
     "leaflet-providers": "^1.1.17",
     "leaflet.locatecontrol": "^0.62.0",


### PR DESCRIPTION
It seems like the latest feature added is missing changes in package.json

When cloning and trying to run `npm install`, I get missing imports in the `import "leaflet-bing-layer"` line. 

Adding leaflet-bing-layer fixes the issue.

