### PR TITLE
Changed to proper license

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "es6"
   ],
   "author": "J.W. Lagendijk <jelte.lagendijk@mendix.com>",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "devDependencies": {
     "autoprefixer": "^7.1.4",
     "babel-core": "^6.26.0",


### PR DESCRIPTION
This is consistent with the included license file. Unless you intended a MIT license, in that case the license file should be updated.